### PR TITLE
Possibility to pass extra data to dynamic zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ When you're using a dynamic zone within your content type you can render them wi
 ```
 This tries to render views with the same name as the component and the data will be available with the `$data` variable.
 
+There is also a possibility to pass extra data to the template. For this you can pass an array as the second parameter:
+```
+@dynamiczone($data->content, ['foo' => 'bar', 'article' => $data])
+```
+The above example makes the variables `$foo` and `$article` available in the template
+
 ## Cache
 
 By default all responses from Strapi will be cached for 1 hour. You can change that with `STRAPI_CACHE` in your `.env`

--- a/src/ViewDirectives/DynamiczoneDirective.php
+++ b/src/ViewDirectives/DynamiczoneDirective.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\View;
 
 class DynamiczoneDirective
 {
-    public function render($components)
+    public function render($components, $data = [])
     {
         $html = '';
 
@@ -14,7 +14,7 @@ class DynamiczoneDirective
             $view = 'strapi.'.$component->__component;
 
             if (View::exists($view)) {
-                $html .= view($view, ['data' => $component]);
+                $html .= view($view, array_merge($data, ['data' => $component]));
             } elseif (!app()->environment('production')) {
                 $html .= '<hr>'.__('View not found (:view).', compact('view')).'<hr>';
             }


### PR DESCRIPTION
This adds the possibility to pass extra data through the dynamic zone directive template. For example, if you want to pass the article data to the dynamic zone view you can use:
```
@dynamiczone($data->content, ['article' => $data, 'foo' => 'bar'])
```

Then in your content component template you can use the variables `$article` and `$foo`.